### PR TITLE
Update app.py to fix pydantic import issue

### DIFF
--- a/litexplore/app.py
+++ b/litexplore/app.py
@@ -25,7 +25,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from pydantic import (
+from pydantic.v1 import (
     BaseModel as _BaseModel,
     BaseSettings,
     Field,


### PR DESCRIPTION
There was an issue while importing pydantic package as BaseSettings has been moved. The quick fix was to replace pydantic by pydantic.v1 inside the app file. However there is a migration guide available on https://docs.pydantic.dev/2.8/migration/ if you want.